### PR TITLE
Create config file and Add Aliases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,27 @@ Use ``exit`` or ``Ctrl-D`` to leave the shell.
 
 Use ``clear`` to clear the screen.
 
+Config File for DemoShell are in following location:
+
+If running on Mac OS:
+~/Library/Application Support/DemoShell/demoshell.ini
+
+If running on Linux:
+~/.local/share/DemoShell/demoshell.ini
+
+If running on Windows:
+C:\Documents and Settings\<User>\Application Data\Local Settings\Doug Hellman\DemoShell\demoshell.ini
+OR:
+C:\Documents and Settings\<User>\Application Data\Doug Hellman\DemoShell\demoshell.ini
+
+To add Aliases:
+Open config file in a text editor
+Edit "Aliases" section as per example below. 
+alias = alias command. It may look something like below.
+
+[Aliases]
+ll = ls -la
+
 Resources
 =========
 

--- a/demoshell/main.py
+++ b/demoshell/main.py
@@ -41,7 +41,9 @@ class DemoShell:
             'clear': self._clear,
         }
 
+        self._aliases = {}
         self._load_config()
+        
 
     def run(self):
         self.loop = urwid.MainLoop(
@@ -58,6 +60,11 @@ class DemoShell:
         if key == 'enter':
             cmd = self.prompt_widget.text
             cmd = cmd.lstrip('$ ')
+
+            if cmd in self._aliases:
+                #Insert code to print the alias here. 
+                cmd = self._aliases[cmd]
+
             if cmd in self._builtins:
                 self._builtins[cmd]()
             elif cmd:
@@ -157,13 +164,15 @@ class DemoShell:
                 Config.add_section('Aliases')
                 #Config.set("Aliases","ll","ls -la")  #This is how you would set alias with code. 
                 Config.write(configfile)    
-            
+
+         
+    #Read Aliases below
         with open(filepath,'r+') as configfile:
             Config = configparser.ConfigParser()
             Config.read(filepath)
-            print(Config.sections())
-            print(Config.get('Aliases','ll'))
-
+            for key in Config['Aliases'].keys():
+                self._aliases[key] = Config.get('Aliases',key)
+                
 
 def main():
     DemoShell().run()

--- a/demoshell/main.py
+++ b/demoshell/main.py
@@ -14,6 +14,8 @@ import subprocess
 import urwid
 import os
 import sys
+from appdirs import *
+import configparser
 
 
 class DemoShell:
@@ -38,6 +40,8 @@ class DemoShell:
             'exit': self._exit,
             'clear': self._clear,
         }
+
+        self._load_config()
 
     def run(self):
         self.loop = urwid.MainLoop(
@@ -136,6 +140,29 @@ class DemoShell:
 
     def received_output(self, data, style):
         self.extend_text(style, data.decode('utf-8'))
+
+    def _load_config(self):
+        appname = "DemoShell"
+        appauthor = "Doug Hellman"    
+        data_dir = user_data_dir(appname,appauthor)
+        filename = "demoshell.ini"
+        filepath = os.path.join(data_dir,filename)
+
+        if (os.path.isdir(data_dir) == False ):
+            os.makedirs(data_dir)
+        
+        if (os.path.isfile(filepath) == False):
+            with open(os.path.join(data_dir,filename),'w+') as configfile:
+                Config = configparser.ConfigParser()
+                Config.add_section('Aliases')
+                #Config.set("Aliases","ll","ls -la")  #This is how you would set alias with code. 
+                Config.write(configfile)    
+            
+        with open(filepath,'r+') as configfile:
+            Config = configparser.ConfigParser()
+            Config.read(filepath)
+            print(Config.sections())
+            print(Config.get('Aliases','ll'))
 
 
 def main():


### PR DESCRIPTION
This creates a config file as mentioned in the README. 
Requires that you actually edit the config files to have aliases. 
You can use this config file for other things in the future as demoshell grows. 