### PR TITLE
Fix #22: Disable mouse events

### DIFF
--- a/demoshell/main.py
+++ b/demoshell/main.py
@@ -77,6 +77,9 @@ class DemoShell:
             # editing. Ignore.
             pass
 
+        elif isinstance(key, tuple) and key[0].startswith('mouse '):
+            pass
+
         else:
             self.extend_text(
                 'error',


### PR DESCRIPTION
Disabling mouse events like a `Unknown keypress ('mouse press', 4.0, 23, 4)`.

![image](https://user-images.githubusercontent.com/151623/44940795-2c209080-adce-11e8-9c6b-f44af657ac62.png)
