### PR TITLE
Support ctrl-c for cancelling a command

### DIFF
--- a/demoshell/main.py
+++ b/demoshell/main.py
@@ -28,6 +28,7 @@ class DemoShell:
     ]
 
     def __init__(self):
+        self.last_command = None
         self.output_widget = urwid.Text(markup='')
         self.prompt_widget = urwid.Edit("$ ")
         self.frame_widget = urwid.Frame(
@@ -49,7 +50,13 @@ class DemoShell:
             unhandled_input=self.on_enter,
             palette=self.palette,
         )
-        self.loop.run()
+        try:
+            old = self.loop.screen.tty_signal_keys(
+                'undefined', 'undefined', 'undefined',
+                'undefined', 'undefined')
+            self.loop.run()
+        finally:
+            self.loop.screen.tty_signal_keys(*old)
 
     def _exit(self):
         raise urwid.ExitMainLoop()
@@ -68,6 +75,13 @@ class DemoShell:
             elif cmd:
                 self._run_external_command(cmd)
             self.prompt_widget.set_edit_text('')
+
+        elif key == 'ctrl c':
+            if (not self.last_command) or isinstance(
+                    self.last_command.poll(), int):
+                pass
+            else:
+                self.last_command.terminate()
 
         elif key == 'ctrl d':
             self._exit()
@@ -100,7 +114,7 @@ class DemoShell:
                 style='stderr',
             )
         )
-        subprocess.Popen(
+        self.last_command = subprocess.Popen(
             cmd,
             stdout=stdout_fd,
             stderr=stderr_fd,


### PR DESCRIPTION
Fix #8

Unmap default CTL+C following: https://github.com/urwid/urwid/blob/master/examples/input_test.py#L84-L89